### PR TITLE
Fix typo in default calendar dayEnd value

### DIFF
--- a/src/views/TimeTracker.vue
+++ b/src/views/TimeTracker.vue
@@ -534,7 +534,7 @@ export default {
       },
 
       dayEnd() {
-          if(! store.get('settings.day_end')) return 7 * 60
+          if(! store.get('settings.day_end')) return 22 * 60
 
           const dateTime = new Date(store.get('settings.day_end'))
 


### PR DESCRIPTION
Although it really shouldn't matter, after fixing this line latest master started showing events in the calendar again for me. Before this change it looked like this:
![screenshot_2022-04-29-115601_grim](https://user-images.githubusercontent.com/1923870/165914407-6dd2724c-c00e-4c31-9875-478d22d299b9.png)

git bisect pointed out commit 4677cd13259aa1ea3bc5335e7c5859219356e149 as the culprit.