### PR TITLE
Color tree select icons on clickup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@heroicons/vue": "^2.0.13",
         "@sentry/electron": "^4.1.1",
+        "@vicons/carbon": "^0.12.0",
+        "@vicons/ionicons5": "^0.12.0",
         "core-js": "^3.26.1",
         "electron-store": "^8.1.0",
         "electron-updater": "^5.3.0",
-        "naive-ui": "^2.33.5",
+        "naive-ui": "^2.34.4",
         "sass": "^1.56.1",
         "v-offline": "^3.3.0",
         "vue": "^3.2.45",
@@ -1728,9 +1730,9 @@
       }
     },
     "node_modules/@css-render/vue3-ssr": {
-      "version": "0.15.11",
-      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.11.tgz",
-      "integrity": "sha512-n+SuqLPbY30FUTM8slX75OaEG+c8XlTOFrAklekX2XQGvBbz9XdBE6hTEgGlV5kPcTMqTJeCG7Vzhs9/29VC7w==",
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.12.tgz",
+      "integrity": "sha512-AQLGhhaE0F+rwybRCkKUdzBdTEM/5PZBYy+fSYe1T9z9+yxMuV/k7ZRqa4M69X+EI1W8pa4kc9Iq2VjQkZx4rg==",
       "peerDependencies": {
         "vue": "^3.0.11"
       }
@@ -2692,6 +2694,11 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/katex": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.14.0.tgz",
+      "integrity": "sha512-+2FW2CcT0K3P+JMR8YG846bmDwplKUTsWgT2ENwdQ1UdVfRk3GQrh6Mi4sTopy30gI8Uau5CEqHTDZ6YvWIUPA=="
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.189",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
@@ -2850,6 +2857,16 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@vicons/carbon": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vicons/carbon/-/carbon-0.12.0.tgz",
+      "integrity": "sha512-kCOgr/ZOhZzoiFLJ8pwxMa2TMxrkCUOA22qExPabus35F4+USqzcsxaPoYtqRd9ROOYiHrSqwapak/ywF0D9bg=="
+    },
+    "node_modules/@vicons/ionicons5": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vicons/ionicons5/-/ionicons5-0.12.0.tgz",
+      "integrity": "sha512-Iy1EUVRpX0WWxeu1VIReR1zsZLMc4fqpt223czR+Rpnrwu7pt46nbnC2ycO7ItI/uqDLJxnbcMC7FujKs9IfFA=="
     },
     "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.4.0",
@@ -12347,12 +12364,13 @@
       }
     },
     "node_modules/naive-ui": {
-      "version": "2.33.5",
-      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.33.5.tgz",
-      "integrity": "sha512-O87zwOduut3Xk9NzGIX+LZYr6sW/Y0oGuNJ6T2dka+14CtHD9iidi8gdxg6obhMpzdwa3SnlxO7nzDLqmXVUwA==",
+      "version": "2.34.4",
+      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.34.4.tgz",
+      "integrity": "sha512-aPG8PDfhSzIzn/jSC9y3Jb3Pe2wHJ7F0cFV1EWlbImSrZECeUmoc+fIcOSWbizoztkKfaUAeKwYdMl09MKkj1g==",
       "dependencies": {
         "@css-render/plugin-bem": "^0.15.10",
         "@css-render/vue3-ssr": "^0.15.10",
+        "@types/katex": "^0.14.0",
         "@types/lodash": "^4.14.181",
         "@types/lodash-es": "^4.17.6",
         "async-validator": "^4.0.7",
@@ -12367,7 +12385,7 @@
         "treemate": "^0.3.11",
         "vdirs": "^0.1.8",
         "vooks": "^0.2.12",
-        "vueuc": "^0.4.47"
+        "vueuc": "^0.4.51"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
@@ -19280,9 +19298,9 @@
       "dev": true
     },
     "node_modules/vueuc": {
-      "version": "0.4.49",
-      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.49.tgz",
-      "integrity": "sha512-WarAC44a/Yx78CxkAgROYLq+LkAeCGA/6wHidVoFmHLbzyF3SiP2nzRNGD/8zJeJInXv18EnWK6A//eGgMMq8w==",
+      "version": "0.4.51",
+      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.51.tgz",
+      "integrity": "sha512-pLiMChM4f+W8czlIClGvGBYo656lc2Y0/mXFSCydcSmnCR1izlKPGMgiYBGjbY9FDkFG8a2HEVz7t0DNzBWbDw==",
       "dependencies": {
         "@css-render/vue3-ssr": "^0.15.10",
         "@juggle/resize-observer": "^3.3.1",
@@ -21636,9 +21654,9 @@
       "requires": {}
     },
     "@css-render/vue3-ssr": {
-      "version": "0.15.11",
-      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.11.tgz",
-      "integrity": "sha512-n+SuqLPbY30FUTM8slX75OaEG+c8XlTOFrAklekX2XQGvBbz9XdBE6hTEgGlV5kPcTMqTJeCG7Vzhs9/29VC7w==",
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.12.tgz",
+      "integrity": "sha512-AQLGhhaE0F+rwybRCkKUdzBdTEM/5PZBYy+fSYe1T9z9+yxMuV/k7ZRqa4M69X+EI1W8pa4kc9Iq2VjQkZx4rg==",
       "requires": {}
     },
     "@develar/schema-utils": {
@@ -22444,6 +22462,11 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/katex": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.14.0.tgz",
+      "integrity": "sha512-+2FW2CcT0K3P+JMR8YG846bmDwplKUTsWgT2ENwdQ1UdVfRk3GQrh6Mi4sTopy30gI8Uau5CEqHTDZ6YvWIUPA=="
+    },
     "@types/lodash": {
       "version": "4.14.189",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
@@ -22602,6 +22625,16 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@vicons/carbon": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vicons/carbon/-/carbon-0.12.0.tgz",
+      "integrity": "sha512-kCOgr/ZOhZzoiFLJ8pwxMa2TMxrkCUOA22qExPabus35F4+USqzcsxaPoYtqRd9ROOYiHrSqwapak/ywF0D9bg=="
+    },
+    "@vicons/ionicons5": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vicons/ionicons5/-/ionicons5-0.12.0.tgz",
+      "integrity": "sha512-Iy1EUVRpX0WWxeu1VIReR1zsZLMc4fqpt223czR+Rpnrwu7pt46nbnC2ycO7ItI/uqDLJxnbcMC7FujKs9IfFA=="
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.4.0",
@@ -30105,12 +30138,13 @@
       }
     },
     "naive-ui": {
-      "version": "2.33.5",
-      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.33.5.tgz",
-      "integrity": "sha512-O87zwOduut3Xk9NzGIX+LZYr6sW/Y0oGuNJ6T2dka+14CtHD9iidi8gdxg6obhMpzdwa3SnlxO7nzDLqmXVUwA==",
+      "version": "2.34.4",
+      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.34.4.tgz",
+      "integrity": "sha512-aPG8PDfhSzIzn/jSC9y3Jb3Pe2wHJ7F0cFV1EWlbImSrZECeUmoc+fIcOSWbizoztkKfaUAeKwYdMl09MKkj1g==",
       "requires": {
         "@css-render/plugin-bem": "^0.15.10",
         "@css-render/vue3-ssr": "^0.15.10",
+        "@types/katex": "^0.14.0",
         "@types/lodash": "^4.14.181",
         "@types/lodash-es": "^4.17.6",
         "async-validator": "^4.0.7",
@@ -30125,7 +30159,7 @@
         "treemate": "^0.3.11",
         "vdirs": "^0.1.8",
         "vooks": "^0.2.12",
-        "vueuc": "^0.4.47"
+        "vueuc": "^0.4.51"
       },
       "dependencies": {
         "highlight.js": {
@@ -35510,9 +35544,9 @@
       "dev": true
     },
     "vueuc": {
-      "version": "0.4.49",
-      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.49.tgz",
-      "integrity": "sha512-WarAC44a/Yx78CxkAgROYLq+LkAeCGA/6wHidVoFmHLbzyF3SiP2nzRNGD/8zJeJInXv18EnWK6A//eGgMMq8w==",
+      "version": "0.4.51",
+      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.51.tgz",
+      "integrity": "sha512-pLiMChM4f+W8czlIClGvGBYo656lc2Y0/mXFSCydcSmnCR1izlKPGMgiYBGjbY9FDkFG8a2HEVz7t0DNzBWbDw==",
       "requires": {
         "@css-render/vue3-ssr": "^0.15.10",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   "dependencies": {
     "@heroicons/vue": "^2.0.13",
     "@sentry/electron": "^4.1.1",
+    "@vicons/carbon": "^0.12.0",
+    "@vicons/ionicons5": "^0.12.0",
     "core-js": "^3.26.1",
     "electron-store": "^8.1.0",
     "electron-updater": "^5.3.0",
-    "naive-ui": "^2.33.5",
+    "naive-ui": "^2.34.4",
     "sass": "^1.56.1",
     "v-offline": "^3.3.0",
     "vue": "^3.2.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "name": "clickup-time-tracker",
   "productName": "Time Tracker",
   "description": "A tool for painlessly tracking time on ClickUp tasks",

--- a/src/background.js
+++ b/src/background.js
@@ -18,25 +18,26 @@ import path from 'path';
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
-// Fetch ClickUp tasks from cache when the app starts up
-ipcMain.on('get-clickup-cards', event => {
-    clickupService.getCachedTasks()
-        .then(tasks => event.reply('set-clickup-cards', tasks))
-        .catch(err => event.reply('fetch-clickup-cards-error', err))
-})
-
-// Clear ClickUp tasks cache & fetch fresh list
-ipcMain.on('refresh-clickup-cards', event => {
-    clickupService.clearCachedTasks()
-    clickupService.getCachedTasks()
-        .then(tasks => event.reply('set-clickup-cards', tasks))
-        .catch(err => event.reply('fetch-clickup-cards-error', err))
-})
-
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
     { scheme: 'app', privileges: { secure: true, standard: true } }
 ])
+
+
+// Fetch ClickUp hierarchy when the app starts up
+ipcMain.on('get-clickup-hierarchy', (event) => {
+    clickupService.getCachedHierarchy()
+        .then(hierarchy => event.reply('set-clickup-hierarchy', hierarchy))
+        .catch(err => event.reply('fetch-clickup-hierarchy-error', err))
+})
+
+// Clear ClickUp hierarchy cache & fetch fresh hierarchy
+ipcMain.on('refresh-clickup-hierarchy', (event) => {
+    clickupService.clearCachedHierarchy()
+    clickupService.getHierarchy()
+        .then(hierarchy => event.reply('set-clickup-hierarchy', hierarchy))
+        .catch(err => event.reply('fetch-clickup-hierarchy-error', err))
+})
 
 async function createWindow() {
     // Create the browser window.

--- a/src/components/TaskCreatorForm.vue
+++ b/src/components/TaskCreatorForm.vue
@@ -223,8 +223,9 @@ function renderSwitcherIcon(option) {
   let icon = null;
   let color = null;
 
-  console.log(store.get('settings'))
-
+  // This branch was split of from another branch were the color was made a setting, so here is the check remains to
+  // see whether a custom color is set or not. This branch will be merged first so this piece will serve no purpose,
+  // till the setting is implemented.
   if (store.get('settings.custom_color_enabled')) {
     color = store.get('settings.color')
   } else {

--- a/src/components/TaskCreatorForm.vue
+++ b/src/components/TaskCreatorForm.vue
@@ -221,7 +221,15 @@ function renderMentionLabel(option) {
 function renderSwitcherIcon(option) {
   // Opion.option = id, label, leaf, name, type, value
   let icon = null;
+  let color = null;
 
+  console.log(store.get('settings'))
+
+  if (store.get('settings.custom_color_enabled')) {
+    color = store.get('settings.color')
+  } else {
+    color = option.option.color
+  }
 
   switch (option.option.type) {
     case 'space':
@@ -235,7 +243,7 @@ function renderSwitcherIcon(option) {
       break;
   }
 
-  return h(NIcon, { size: '15px', id: 'cascader-icon' }, { default: () => h(icon) })
+  return h(NIcon, { size: '15px', id: 'cascader-icon', color: color }, { default: () => h(icon) })
 }
 
 function onUpdateIndeterminateKeys(keys) {

--- a/src/components/TaskCreatorForm.vue
+++ b/src/components/TaskCreatorForm.vue
@@ -1,0 +1,349 @@
+<script setup>
+import {NAvatar, NButton, NForm, NIcon, NMention, NH1, NTreeSelect, NFormItem, useNotification, NConfigProvider} from "naive-ui";
+import {ArrowPathIcon} from "@heroicons/vue/20/solid";
+import {Planet, List, } from '@vicons/ionicons5'
+import {CircleFilled} from "@vicons/carbon";
+import {h, onMounted, ref, defineEmits} from "vue";
+import {ipcRenderer} from 'electron';
+import clickupService from "@/clickup-service";
+import store from "@/store";
+
+const props = defineProps({
+  start: {
+    type: Date,
+    required: true,
+  },
+  end: {
+    type: Date,
+    required: true,
+  },
+})
+
+const notification = useNotification();
+
+// Emits
+const emit = defineEmits(['close', 'create']);
+
+// Refs
+let clickUpItems = ref([]);
+let loadingClickup = ref(false);
+let mentionable = ref([]);
+
+let createForm = ref(null);
+
+let formValue = ref({
+  task: {
+    taskId: null,
+    description: null,
+  },
+})
+
+const rules = ref({
+  task: {
+    taskId: {
+      required: true,
+      message: 'Please select a task'
+    },
+    description: {
+      required: store.get('settings.requireDescription'),
+      message: 'Please describe what you worked on',
+      trigger: ['blur']
+    },
+  },
+})
+
+// Naive UI custom theme
+
+/**
+ * Use this for type hints under js file
+ * @type import('naive-ui').GlobalThemeOverrides
+ */
+const customTheme = {
+  common: {
+    "textColorDisabled": "-n-text-color"
+  }
+}
+
+
+/*
+|--------------------------------------------------------------------------
+| CASCASER HANDLERS
+|--------------------------------------------------------------------------
+ */
+
+// A function that builds the cascader options. loops through the clickupItems and builds the options
+async function getClickUpHierarchy() {
+  loadingClickup.value = true;
+  new Promise((resolve, reject) => {
+    ipcRenderer.send("get-clickup-hierarchy");
+    console.info("Fetching Clickup hierarchy (from cache when available)...");
+    ipcRenderer.once("set-clickup-hierarchy", (event, hierarchy) => {
+      resolve(hierarchy)
+    });
+
+    ipcRenderer.once("fetch-clickup-hierarchy-error", (event, error) => {
+      onError({
+        error,
+        title: "Failed to fetch Clickup hierarchy in the background",
+        content: "You can try again later by pressing the refresh button when searching for a space",
+      })
+      reject();
+    });
+
+  }).then((hierarchy) => {
+    clickUpItems.value = hierarchy
+    onSuccess({
+      title: "Clickup hierarchy refreshed",
+      content: "The Clickup hierarchy has been refreshed in the background",
+    })
+    loadingClickup.value = false;
+  })
+}
+
+async function refreshClickUpHierarchy() {
+  loadingClickup.value = true;
+  new Promise((resolve, reject) => {
+    ipcRenderer.send("refresh-clickup-hierarchy");
+    console.info("Fetching Clickup hierarchy (from cache when available)...");
+    ipcRenderer.once("set-clickup-hierarchy", (event, hierarchy) => {
+      resolve(hierarchy)
+    });
+
+    ipcRenderer.once("fetch-clickup-hierarchy-error", (event, error) => {
+      onError({
+        error,
+        title: "Failed to fetch Clickup hierarchy in the background",
+        content: "You can try again later by pressing the refresh button when searching for a space",
+      })
+      reject();
+    });
+
+  }).then((hierarchy) => {
+    clickUpItems.value = hierarchy
+    onSuccess({
+      title: "Clickup hierarchy refreshed",
+      content: "The Clickup hierarchy has been refreshed in the background",
+    })
+    loadingClickup.value = false;
+  })
+}
+
+/*
+|--------------------------------------------------------------------------
+| BUTTON HANDLERS
+|--------------------------------------------------------------------------
+*/
+
+
+function createTask() {
+  createForm.value?.validate((errors) => {
+    if (errors) {
+      console.error('Form validation failed:', errors);
+      onError({
+        title: 'Form validation failed',
+        content: 'Please check the form for errors',
+      })
+    } else {
+      pushToClickup()
+      onSuccess({
+        title: 'Task created',
+        content: 'The task has been created in Clickup',
+      });
+
+    }
+  })
+
+  const pushToClickup = () => {
+    clickupService.createTimeTrackingEntry(
+        formValue.value.task.taskId,
+        formValue.value.task.description,
+        props.start,
+        props.end
+    ).then(entry => {
+      pushEntryToCalendar(entry);
+    }).catch(error => {
+          cancelTaskCreation()
+          this.error({
+            error,
+            title: "Looks like something went wrong",
+            content: "There was a problem while pushing to Clickup. Check your console & internet connection and try again",
+          });
+        });
+  }
+}
+
+function pushEntryToCalendar(entry) {
+  console.log('Pushing entry to calendar')
+  emit('create', entry);
+}
+
+function cancelTaskCreation() {
+  emit('close');
+}
+
+/*
+|--------------------------------------------------------------------------
+| NOTIFICATION HANDLERS
+|--------------------------------------------------------------------------
+*/
+
+// eslint-disable-next-line no-unused-vars
+function onSuccess(options) {
+  notification.success({duration: 5000, ...options});
+}
+
+function onError(options) {
+  notification.error({duration: 5000, ...options});
+
+  if (options.error) {
+    console.error(options.error);
+  }
+}
+
+/*
+|--------------------------------------------------------------------------
+| MISC & EASTER EGG LAND
+|--------------------------------------------------------------------------
+*/
+
+function renderMentionLabel(option) {
+  return h('div', {style: 'display: flex; align-items: center;'}, [
+    h(NAvatar, {
+      style: 'margin-right: 8px;',
+      size: 24,
+      round: true,
+      src: option.avatar
+    }, option.avatar ? '' : option.initials,),
+    option.value
+  ])
+}
+
+function renderSwitcherIcon(option) {
+  // Opion.option = id, label, leaf, name, type, value
+  let icon = null;
+
+
+  switch (option.option.type) {
+    case 'space':
+      icon = Planet
+      break;
+    case 'list':
+      icon = List;
+      break;
+    default:
+      icon = CircleFilled;
+      break;
+  }
+
+  return h(NIcon, { size: '15px', id: 'cascader-icon' }, { default: () => h(icon) })
+}
+
+function onUpdateIndeterminateKeys(keys) {
+  console.log(keys);
+}
+
+/*
+|--------------------------------------------------------------------------
+| MAIN
+|--------------------------------------------------------------------------
+*/
+
+// Fetch Clickup spaces on mount
+onMounted(async () => {
+  await getClickUpHierarchy()
+})
+</script>
+
+/*
+|--------------------------------------------------------------------------
+| TEMPLATE
+|--------------------------------------------------------------------------
+*/
+
+<template>
+  <n-form
+      ref="createForm"
+      :model="formValue.task"
+      :rules="rules.task"
+      size="large"
+  >
+    <n-h1>What are you working on?</n-h1>
+
+    <div class="flex space-x-2">
+      <n-form-item path="taskId" class="flex-grow" :show-label="false">
+        <n-config-provider class="flex-grow" :theme-overrides="customTheme">
+          <n-tree-select
+              v-model:value="formValue.task.taskId"
+              :options="clickUpItems"
+              :disabled="loadingClickup"
+              :placeholder="
+                loadingClickup
+                  ? 'Loading tasks...'
+                  : 'Select a task or subtask'
+              "
+
+              :size="'large'"
+              :clearable="true"
+              :expand-trigger="'hover'"
+              :filterable="true"
+              :key-field="'value'"
+              :disabled-field="'disable'"
+              :render-prefix="renderSwitcherIcon"
+
+              @update:indeterminate-keys="onUpdateIndeterminateKeys"
+          />
+
+        </n-config-provider>
+      </n-form-item>
+
+      <!-- Refresh button -->
+      <n-button
+          :disabled="loadingClickup"
+          circle
+          class="mt-0.5 bg-transparent color-gray-600"
+          secondary
+          strong
+          @click="refreshClickUpHierarchy"
+      >
+        <n-icon class="flex items-center justify-center" name="refresh" size="20">
+          <div v-if="loadingClickup" class="w-2 h-2 bg-blue-800 rounded-full animate-ping"></div>
+          <arrow-path-icon v-else/>
+        </n-icon>
+      </n-button>
+    </div>
+
+    <!-- Description textbox -->
+    <div class="flex space-x-2">
+      <n-form-item path="description" class="flex-grow" :show-label="false">
+        <n-mention
+            v-model:value="formValue.task.description"
+            :options="mentionable"
+            :render-label="renderMentionLabel"
+            placeholder="Describe what you worked on"
+            type="textarea"
+            :disabled="loadingClickup"
+        />
+      </n-form-item>
+    </div>
+
+    <!-- Create and cancel buttons -->
+    <div class="flex justify-end space-x-2">
+      <n-button
+          round
+          @click="cancelTaskCreation"
+
+      >Cancel
+      </n-button>
+      <n-button
+          round
+          type="primary"
+          @click="createTask"
+      >Create
+      </n-button>
+    </div>
+  </n-form>
+</template>
+
+<style scoped>
+
+</style>

--- a/src/model/ClickUpModels.js
+++ b/src/model/ClickUpModels.js
@@ -1,0 +1,54 @@
+export const ClickUpType = {
+    SPACE: "space",
+    LIST: "list",
+    TASK: "task",
+    SUBTASK: "subtask",
+}
+
+export class ClickUpItem{
+    constructor(id, name, type){
+        if (!Object.values(ClickUpType).includes(type)){
+            throw new Error("Invalid type");
+        }
+
+        this.id = id;
+        this.value = id;
+
+        this.name = name;
+        this.label = name;
+
+        this.type = type;
+
+        switch (this.type){
+            case ClickUpType.SPACE:
+                this.disable = true;
+                break;
+            case ClickUpType.LIST:
+                this.disable = true;
+                break;
+            case ClickUpType.TASK:
+                this.disable = false;
+                break;
+            case ClickUpType.SUBTASK:
+                this.disable = false;
+                break;
+        }
+    }
+
+    addChild(child){
+        if (!(child instanceof ClickUpItem)){
+            throw new Error("Child must be of type ClickUpItem");
+        }
+        if (!this.children){
+            this.children = [];
+        }
+        this.children.push(child);
+    }
+
+    addChildren(children){
+        if (!Array.isArray(children)){
+            throw new Error("Children must be an array");
+        }
+        children.forEach(child => this.addChild(child));
+    }
+}

--- a/src/model/ClickUpModels.js
+++ b/src/model/ClickUpModels.js
@@ -4,9 +4,51 @@ export const ClickUpType = {
     TASK: "task",
     SUBTASK: "subtask",
 }
+export class ClickUpItemFactory {
 
+    constructor() {
+        this.colorMap = new Map();
+    }
+
+    createItem(item, type) {
+        if (item instanceof ClickUpItem){
+            return item;
+        }
+        // Colors
+        if (item.color && !this.colorMap[item.color]){
+            console.log("Adding color", item.id, item.color)
+            this.colorMap.set(item.id, item.color)
+        } else if (item.space.id && this.colorMap.has(item.space.id)){
+            item.color = this.colorMap.get(item.space.id);
+        }
+        // Create item
+        if (typeof item === "object"){
+            // This is the only place where clickup items are created
+            return new ClickUpItem(item.id, item.name, type, item.color);
+        }
+        throw new Error("Invalid item");
+    }
+
+    createSpace(item){
+        return this.createItem(item, ClickUpType.SPACE);
+    }
+
+    createList(item){
+        return this.createItem(item, ClickUpType.LIST);
+    }
+
+    createTask(item){
+        return this.createItem(item, ClickUpType.TASK);
+    }
+
+    createSubtask(item){
+        return this.createItem(item, ClickUpType.SUBTASK);
+    }
+
+}
 export class ClickUpItem{
-    constructor(id, name, type){
+    // This is the only place where the clickup item is defined
+    constructor(id, name, type, color){
         if (!Object.values(ClickUpType).includes(type)){
             throw new Error("Invalid type");
         }
@@ -33,6 +75,8 @@ export class ClickUpItem{
                 this.disable = false;
                 break;
         }
+
+        this.color = color;
     }
 
     addChild(child){

--- a/src/views/TimeTracker.vue
+++ b/src/views/TimeTracker.vue
@@ -1,40 +1,38 @@
 <template>
-
-
   <member-selector
-    v-if="store.get('settings.admin_features_enabled')"
-    :open="memberSelectorOpen"
+      v-if="store.get('settings.admin_features_enabled')"
+      :open="memberSelectorOpen"
   />
 
   <!-- START | Calendar view -->
   <vue-cal
-    :editable-events="{ drag: true, resize: true, create: true }"
-    :hide-weekends="!store.get('settings.show_weekend')"
-    :disable-views="['years', 'year', 'month', 'day']"
-    :on-event-dblclick="onTaskDoubleClick"
-    :on-event-click="onTaskSingleClick"
-    :on-event-create="onTaskCreate"
-    :drag-to-create-threshold="20"
-    :click-to-navigate="false"
-    :hide-view-selector="true"
-    :watch-real-time="true"
-    :time-cell-height="90"
-    :time-from="dayStart"
-    :time-to="dayEnd"
-    :snap-to-time="15"
-    :events="events"
-    @ready="fetchEvents"
-    @view-change="fetchEvents"
-    @event-drop="updateTimeTrackingEntry"
-    @event-duration-change="updateTimeTrackingEntry"
-    @keydown.meta.delete.exact="deleteSelectedTask()"
-    @keydown.meta.v.exact="duplicateSelectedTask()"
-    @keydown.meta.d.exact="duplicateSelectedTask()"
-    @keydown.meta.x.exact="refreshBackgroundImage()"
-    @mousedown="memberSelectorOpen = false"
-    active-view="week"
-    today-button
-    ref="calendar"
+      :editable-events="{ drag: true, resize: true, create: true }"
+      :hide-weekends="!store.get('settings.show_weekend')"
+      :disable-views="['years', 'year', 'month', 'day']"
+      :on-event-dblclick="onTaskDoubleClick"
+      :on-event-click="onTaskSingleClick"
+      :on-event-create="onTaskCreate"
+      :drag-to-create-threshold="20"
+      :click-to-navigate="false"
+      :hide-view-selector="true"
+      :watch-real-time="true"
+      :time-cell-height="90"
+      :time-from="dayStart"
+      :time-to="dayEnd"
+      :snap-to-time="15"
+      :events="events"
+      @ready="fetchEvents"
+      @view-change="fetchEvents"
+      @event-drop="updateTimeTrackingEntry"
+      @event-duration-change="updateTimeTrackingEntry"
+      @keydown.meta.delete.exact="deleteSelectedTask()"
+      @keydown.meta.v.exact="duplicateSelectedTask()"
+      @keydown.meta.d.exact="duplicateSelectedTask()"
+      @keydown.meta.x.exact="refreshBackgroundImage()"
+      @mousedown="memberSelectorOpen = false"
+      active-view="week"
+      today-button
+      ref="calendar"
   >
     <template v-slot:title="{ title }">
       <div class="flex items-center space-x-4">
@@ -42,19 +40,19 @@
 
         <!-- START | Extra controls -->
         <div
-          class="flex space-x-1 text-gray-600"
-          style="-webkit-app-region: no-drag"
+            class="flex space-x-1 text-gray-600"
+            style="-webkit-app-region: no-drag"
         >
           <router-link :to="{ name: 'settings' }" replace class="hover:text-gray-800">
-            <cog-icon class="w-5" />
+            <cog-icon class="w-5"/>
           </router-link>
 
           <button
-            v-if="store.get('settings.admin_features_enabled')"
-            @click="memberSelectorOpen = !memberSelectorOpen"
-            class="hover:text-gray-800"
+              v-if="store.get('settings.admin_features_enabled')"
+              @click="memberSelectorOpen = !memberSelectorOpen"
+              class="hover:text-gray-800"
           >
-            <users-icon class="w-5" />
+            <users-icon class="w-5"/>
           </button>
         </div>
         <!-- End | Extra controls -->
@@ -63,72 +61,74 @@
 
     <!-- START | Custom Day heading -->
     <template v-slot:weekday-heading="{ heading, view }">
-        <div class="flex flex-col justify-center sm:flex-row">
+      <div class="flex flex-col justify-center sm:flex-row">
 
-            <div>
-                <span class="full">{{ heading.label }}</span>
-                <span class="small">{{ heading.date.toLocaleDateString('en-US', { weekday: 'short' }) }}</span>
-                <span class="xsmall">{{ heading.label[0] }}</span>
-                <span>&nbsp;{{ heading.date.toLocaleDateString('en-US', { day: 'numeric' }) }}</span>
-            </div>
-
-            <div
-                v-if="hasTimeTrackedOn(heading.date, view.events)"
-                class="inline-flex items-center ml-2 text-xs text-gray-600 space-x-[2px]"
-            >
-                <clock-icon class="w-3 -mt-0.5" />
-                <span class="italic">{{ totalHoursOnDate(heading.date, view.events) }}</span>
-            </div>
-
+        <div>
+          <span class="full">{{ heading.label }}</span>
+          <span class="small">{{ heading.date.toLocaleDateString('en-US', {weekday: 'short'}) }}</span>
+          <span class="xsmall">{{ heading.label[0] }}</span>
+          <span>&nbsp;{{ heading.date.toLocaleDateString('en-US', {day: 'numeric'}) }}</span>
         </div>
+
+        <div
+            v-if="hasTimeTrackedOn(heading.date, view.events)"
+            class="inline-flex items-center ml-2 text-xs text-gray-600 space-x-[2px]"
+        >
+          <clock-icon class="w-3 -mt-0.5"/>
+          <span class="italic">{{ totalHoursOnDate(heading.date, view.events) }}</span>
+        </div>
+
+      </div>
     </template>
     <!-- END | Custom Day heading -->
 
     <!-- START | Custom Event template -->
-    <template v-slot:event="{ event }" >
+    <template v-slot:event="{ event }">
 
-        <div class="vuecal__event-title">
-            <span v-text="event.title" />
+      <div class="vuecal__event-title">
+        <span v-text="event.title"/>
 
-            <!-- START | Task context popover -->
-            <n-popover trigger="hover" :delay="500" :duration="60" width="260">
+        <!-- START | Task context popover -->
+        <n-popover trigger="hover" :delay="500" :duration="60" width="260">
 
-                <template #trigger>
+          <template #trigger>
                     <span class="vuecal__event-task-info-popover absolute top-0 right-0 py-0.5 px-1 cursor-pointer">
                         <information-circle-icon class="w-4 text-blue-300 transition-all hover:scale-125"/>
                     </span>
-                </template>
+          </template>
 
-                <template #header>
-                    <span class="font-semibold text-gray-700" v-text="event.title"></span>
-                </template>
+          <template #header>
+            <span class="font-semibold text-gray-700" v-text="event.title"></span>
+          </template>
 
-                <span v-text="event.description" class="whitespace-pre-wrap"></span>
+          <span v-text="event.description" class="whitespace-pre-wrap"></span>
 
-                <hr class="my-2 -mx-3.5" />
+          <hr class="my-2 -mx-3.5"/>
 
-                <button @click="shell.openExternal(event.taskUrl)" class="flex items-center py-1 space-x-1 italic text-gray-500 hover:text-gray-700">
-                    <img class="mt-1 w-7" src="@/assets/images/white-rounded-logo.svg" alt="Open task in ClickUp">
-                    <span>Open in ClickUp</span>
-                </button>
+          <button @click="shell.openExternal(event.taskUrl)"
+                  class="flex items-center py-1 space-x-1 italic text-gray-500 hover:text-gray-700">
+            <img class="mt-1 w-7" src="@/assets/images/white-rounded-logo.svg" alt="Open task in ClickUp">
+            <span>Open in ClickUp</span>
+          </button>
 
-                <button @click="onTaskDoubleClick(event)" class="flex items-center py-1 space-x-1 italic text-gray-500 hover:text-gray-700">
-                    <pencil-icon class="w-4 mx-1.5" />
-                    <span>Open details</span>
-                </button>
+          <button @click="onTaskDoubleClick(event)"
+                  class="flex items-center py-1 space-x-1 italic text-gray-500 hover:text-gray-700">
+            <pencil-icon class="w-4 mx-1.5"/>
+            <span>Open details</span>
+          </button>
 
-            </n-popover>
-            <!-- END | Task context popover -->
+        </n-popover>
+        <!-- END | Task context popover -->
 
-        </div>
+      </div>
 
-        <!-- START | Time from/to -->
-        <div class="vuecal__event-time">
-            {{ event.start.formatTime('HH:mm') }}
-            <span class="mx-1">-</span>
-            {{ event.end.formatTime('HH:mm') }}
-        </div>
-        <!-- END | Time from/to -->
+      <!-- START | Time from/to -->
+      <div class="vuecal__event-time">
+        {{ event.start.formatTime('HH:mm') }}
+        <span class="mx-1">-</span>
+        {{ event.end.formatTime('HH:mm') }}
+      </div>
+      <!-- END | Time from/to -->
 
     </template>
     <!-- END | Custom Event template -->
@@ -138,70 +138,25 @@
 
   <!-- START | Task creation modal -->
   <n-modal
-    v-model:show="showTaskCreationModal"
-    @keydown.esc="cancelTaskCreation"
-    :mask-closable="false"
+      v-model:show="showTaskCreationModal"
+      @keydown.esc="cancelTaskCreation"
+      :mask-closable="false"
   >
     <n-card
-      :bordered="false"
-      class="max-w-xl"
-      title="What did you work on?"
-      size="huge"
-      role="dialog"
-      aria-modal="true"
+        :bordered="false"
+        class="max-w-xl"
+        size="huge"
+        role="dialog"
+        aria-modal="true"
     >
-      <template #header> What did you work on? </template>
 
-      <n-form :model="selectedTask" :rules="rules.task" ref="createForm" size="large">
-        <div class="flex space-x-2">
-          <!-- Searchable select -->
-          <n-form-item path="taskId" :show-label="false" class="flex-grow">
-            <n-select
-              filterable
-              :options="clickupCards"
-              :disabled="loadingClickupCards"
-              v-model:value="selectedTask.taskId"
-              :render-label="renderTaskOptionLabel"
-              :render-tag="({ option, handleClose }) => option.name"
-              :placeholder="
-                loadingClickupCards
-                  ? 'Refreshing Card list...'
-                  : 'Please Select card to start tracking'
-              "
-            />
-          </n-form-item>
+      <TaskCreatorForm
+        @close="cancelTaskCreation"
+        @create="pushTimeTrackingEntry"
+        :start="selectedTask.start"
+        :end="selectedTask.end"
+      />
 
-          <!-- Refresh button -->
-          <n-button strong secondary circle
-            @click="refreshClickupCards()"
-            :disabled="loadingClickupCards"
-            class="mt-0.5 bg-transparent color-gray-600"
-          >
-            <n-icon name="refresh" size="20" class="flex items-center justify-center">
-              <div v-if="loadingClickupCards" class="w-2 h-2 bg-blue-800 rounded-full animate-ping"></div>
-              <arrow-path-icon v-else />
-            </n-icon>
-          </n-button>
-        </div>
-
-        <!-- Description textbox -->
-        <n-form-item path="description" :show-label="false">
-          <n-mention
-                type="textarea"
-                v-model:value="selectedTask.description"
-                :options="mentionable"
-                :render-label="renderMentionLabel"
-                placeholder="Describe what you worked on"
-            />
-        </n-form-item>
-      </n-form>
-
-      <template #footer>
-        <div class="flex justify-end space-x-2">
-          <n-button @click="cancelTaskCreation()" round>Cancel</n-button>
-          <n-button @click="createTask()" round type="primary">Create</n-button>
-        </div>
-      </template>
     </n-card>
   </n-modal>
   <!-- END | Task creation modal -->
@@ -209,26 +164,26 @@
   <!-- START | Task detail modal -->
   <n-modal v-model:show="showTaskDetailsModal">
     <n-card
-      :bordered="false"
-      class="max-w-xl"
-      title="Edit tracking entry"
-      size="huge"
-      role="dialog"
-      aria-modal="true"
+        :bordered="false"
+        class="max-w-xl"
+        title="Edit tracking entry"
+        size="huge"
+        role="dialog"
+        aria-modal="true"
     >
       <template #header>
         <span class="flex items-center space-x-3">
           <n-popconfirm
-            v-if="selectedTask.deletable"
-            :negative-text="null"
-            @positive-click="deleteSelectedTask"
-            positive-text="delete"
-            :show-icon="false"
+              v-if="selectedTask.deletable"
+              :negative-text="null"
+              @positive-click="deleteSelectedTask"
+              positive-text="delete"
+              :show-icon="false"
           >
             <template #trigger>
               <n-button secondary circle type="error">
                 <n-icon name="delete-tracking-entry" size="18">
-                  <trash-icon />
+                  <trash-icon/>
                 </n-icon>
               </n-button>
             </template>
@@ -245,15 +200,15 @@
         <!-- TODO: Show current task column -->
 
         <n-form :model="selectedTask" :rules="rules.task" ref="editForm" size="large">
-            <n-form-item path="description" :show-label="false">
-                <n-mention
-                    type="textarea"
-                    v-model:value="selectedTask.description"
-                    :options="mentionable"
-                    :render-label="renderMentionLabel"
-                    placeholder="Describe what you worked on"
-                />
-            </n-form-item>
+          <n-form-item path="description" :show-label="false">
+            <n-mention
+                type="textarea"
+                v-model:value="selectedTask.description"
+                :options="mentionable"
+                :render-label="renderMentionLabel"
+                placeholder="Describe what you worked on"
+            />
+          </n-form-item>
         </n-form>
 
       </n-space>
@@ -272,86 +227,110 @@
 
 
 <script>
-import { ref, h } from "vue";
-import { RouterLink } from "vue-router";
-import { ipcRenderer } from "electron";
+import {ref, h} from "vue";
+import {RouterLink} from "vue-router";
+
 const shell = require('electron').shell;
 
 import VueCal from "vue-cal";
 import "@/assets/vuecal.scss";
 
 import store from "@/store";
-import { isEmptyObject } from "@/helpers";
+import {isEmptyObject} from "@/helpers";
 import eventFactory from "@/events-factory";
 import clickupService from "@/clickup-service";
 
 import MemberSelector from '@/components/MemberSelector'
-import { CogIcon, UsersIcon, InformationCircleIcon, ArrowPathIcon } from "@heroicons/vue/20/solid";
-import { ClockIcon, TrashIcon, PencilIcon } from "@heroicons/vue/24/outline";
-import { NMention, NModal,  NCard,  NForm,  NFormItem,  NSpace,  NIcon,  NPopconfirm, NPopover,  NButton,  NSelect, NAvatar, useNotification } from "naive-ui";
+import {CogIcon, UsersIcon, InformationCircleIcon} from "@heroicons/vue/20/solid";
+import {ClockIcon, TrashIcon, PencilIcon} from "@heroicons/vue/24/outline";
+import {
+  NMention,
+  NModal,
+  NCard,
+  NForm,
+  NFormItem,
+  NSpace,
+  NIcon,
+  NPopconfirm,
+  NPopover,
+  NButton,
+  NAvatar,
+  useNotification
+} from "naive-ui";
+import TaskCreatorForm from "@/components/TaskCreatorForm.vue";
 
 export default {
-  components: { VueCal, MemberSelector, RouterLink, NMention, NModal, NCard, NForm, NFormItem, NSpace, NIcon, NPopconfirm, NPopover, NButton, NSelect, ArrowPathIcon, ClockIcon, CogIcon, UsersIcon, TrashIcon, PencilIcon, InformationCircleIcon },
+  components: {
+    TaskCreatorForm,
+    VueCal,
+    MemberSelector,
+    RouterLink,
+    NMention,
+    NModal,
+    NCard,
+    NForm,
+    NFormItem,
+    NSpace,
+    NIcon,
+    NPopconfirm,
+    NPopover,
+    NButton,
+    ClockIcon,
+    CogIcon,
+    UsersIcon,
+    TrashIcon,
+    PencilIcon,
+    InformationCircleIcon
+  },
 
   setup() {
     const notification = useNotification();
+    const createForm = ref(null);
 
     return {
       shell,
       store,
 
+      createForm,
       events: ref([]),
-      selectedTask: ref({}),
       mentionable: ref([]),
-
-      clickupCards: ref([]),
-      loadingClickupCards: ref(false),
 
       deleteCallable: ref(() => null),
       showTaskCreationModal: ref(false),
       showTaskDetailsModal: ref(false),
       memberSelectorOpen: ref(false),
+      selectedTask: ref({}),
 
-      rules: {
-          task: {
-              taskId: {
-                required: true,
-                message: "Please select a task to start tracking",
-              },
-              description: {
-                required: store.get('settings.require_description'),
-                trigger: ["blur"],
-                message: "Please provide a description",
-              }
-          }
+      rules: ref({
+        task: {
+          taskId: {
+            required: true,
+            message: 'Please select a task'
+          },
+          description: {
+            required: store.get('settings.requireDescription'),
+            message: 'Please describe what you worked on',
+            trigger: ['blur']
+          },
+        },
+      }),
+
+      success(options) {
+        notification.success({duration: 5000, ...options});
       },
 
       error(options) {
-        notification.error({ duration: 5000, ...options });
+        notification.error({duration: 5000, ...options});
 
         if (options.error) {
           console.error(options.error);
         }
-      },
+      }
     };
   },
 
   mounted() {
     // Register background process listeners
-    ipcRenderer.on("set-clickup-cards", (event, cards) =>
-      this.onClickupCardsRefreshed(cards)
-    );
-
-    ipcRenderer.on("fetch-clickup-cards-error", (event, error) =>
-      this.error({
-          error,
-          title: "Failed to fetch Clickup tasks in the background",
-          content: "You can try again later by pressing the refresh button when searching for a task",
-      })
-    );
-
-    this.getClickupCards();
-
     this.fetchMentionableUsers();
 
     // Load background image if set
@@ -359,21 +338,21 @@ export default {
   },
 
   computed: {
-      dayStart() {
-          if(! store.get('settings.day_start')) return 7 * 60
+    dayStart() {
+      if (!store.get('settings.day_start')) return 7 * 60
 
-          const dateTime = new Date(store.get('settings.day_start'))
+      const dateTime = new Date(store.get('settings.day_start'))
 
-          return dateTime.getHours() * 60;
-      },
+      return dateTime.getHours() * 60;
+    },
 
-      dayEnd() {
-          if(! store.get('settings.day_end')) return 22 * 60
+    dayEnd() {
+      if (!store.get('settings.day_end')) return 22 * 60
 
-          const dateTime = new Date(store.get('settings.day_end'))
+      const dateTime = new Date(store.get('settings.day_end'))
 
-          return dateTime.getHours() * 60;
-      },
+      return dateTime.getHours() * 60;
+    },
   },
 
   methods: {
@@ -382,56 +361,20 @@ export default {
     | FETCH TIME TRACKING ENTRIES
     |--------------------------------------------------------------------------
     */
-    async fetchEvents({ startDate, endDate }) {
+    async fetchEvents({startDate, endDate}) {
       clickupService
-        .getTimeTrackingRange(startDate, endDate)
-        .then(entries => {
-          this.events = entries
-            .map((entry) => eventFactory.fromClickup(entry)) // Map into Event DTO
-            .filter((entry) => entry); // Remove falsey entries
-        })
-        .catch(error => this.error({
+          .getTimeTrackingRange(startDate, endDate)
+          .then(entries => {
+            this.events = entries
+                .map((entry) => eventFactory.fromClickup(entry)) // Map into Event DTO
+                .filter((entry) => entry); // Remove falsey entries
+          })
+          .catch(error => this.error({
             error,
             title: "Could not fetch time tracking entries",
             content: "Check your console & internet connection and try again",
-        }));
+          }));
     },
-
-    /*
-    |--------------------------------------------------------------------------
-    | FETCH TIME CLICKUP CARDS FOR SELECT FIELD
-    |--------------------------------------------------------------------------
-    */
-    // Instruct background process to get cached clickup cards
-    getClickupCards() {
-      this.loadingClickupCards = true;
-      ipcRenderer.send("get-clickup-cards");
-
-      console.info("Fetching Clickup cards (from cache when available)...");
-    },
-
-    refreshClickupCards() {
-        this.loadingClickupCards = true;
-        ipcRenderer.send("refresh-clickup-cards");
-
-        console.info("Refreshing Clickup cards...");
-    },
-
-    // Fired when background process sends us the refreshed cards
-    onClickupCardsRefreshed(cards) {
-
-      this.clickupCards = cards.map((card) => ({
-        value: card.id,
-        name: `${card.name}`,
-        folder: `${card.folder}`,
-        label: `${card.name} ${card.folder}` // Native UI uses this for fuzzy searching
-      }));
-
-      this.loadingClickupCards = false;
-
-      console.info("Clickup cards refreshed!");
-    },
-
     /*
     |--------------------------------------------------------------------------
     | CREATE A TASK
@@ -453,67 +396,37 @@ export default {
       return this.selectedTask;
     },
 
-    createTask() {
-      if (isEmptyObject(this.selectedTask)) return;
-
-      this.$refs.createForm.validate()
-        .then(() => pushToClickup())
-        .catch(errors => console.error(errors))
-
-      const pushToClickup = () => {
-        clickupService.createTimeTrackingEntry(
-          this.selectedTask.taskId,
-          this.selectedTask.description,
-          this.selectedTask.start,
-          this.selectedTask.end
-        )
-        .then(entry => {
-          console.info(`Created time tracking entry for: ${entry.task.name}`);
-
-          this.selectedTask = eventFactory.updateFromRemote(
-            this.selectedTask,
-            entry
-          );
-          // Explicitly push to model so time update works properly
-          this.events.push(this.selectedTask);
-
-          this.closeCreationModal();
-        })
-        .catch(error => {
-          this.cancelTaskCreation();
-
-          this.error({
-            error,
-            title: "Looks like something went wrong",
-            content: "There was a problem while pushing to Clickup. Check your console & internet connection and try again",
-          });
-        });
-      }
-    },
-
     duplicateSelectedTask() {
       clickupService
-        .createTimeTrackingEntry(
-          this.selectedTask.taskId,
-          this.selectedTask.description,
-          this.selectedTask.start,
-          this.selectedTask.end
-        )
-        .then((entry) => {
-          this.events.push(eventFactory.fromClickup(entry));
+          .createTimeTrackingEntry(
+              this.selectedTask.taskId,
+              this.selectedTask.description,
+              this.selectedTask.start,
+              this.selectedTask.end
+          )
+          .then((entry) => {
+            this.events.push(eventFactory.fromClickup(entry));
 
-          console.info(
-            `Duplicated time tracking entry for: ${entry.task.name}`
-          );
-        })
-        .catch(error => this.error({
+            console.info(
+                `Duplicated time tracking entry for: ${entry.task.name}`
+            );
+          })
+          .catch(error => this.error({
             error,
             title: "Duplication failed",
             content: "There was a problem while pushing to Clickup. Check your console & internet connection and try again",
-        }));
+          }));
+    },
+
+    pushTimeTrackingEntry(event){
+      console.log("Received event from form:" + event)
+      this.selectedTask = eventFactory.updateFromRemote(this.selectedTask, event);
+      this.events.push(this.selectedTask);
+      this.closeCreationModal();
     },
 
     cancelTaskCreation() {
+      console.log("Canceling task creation")
       this.closeCreationModal();
       this.deleteCallable();
     },
@@ -523,10 +436,10 @@ export default {
     },
 
     renderTaskOptionLabel(option) {
-        return h('div', { class: 'my-1' }, [
-            h('div', option.name),
-            h('div', { class: 'text-xs text-gray-500' }, option.folder)
-        ])
+      return h('div', {class: 'my-1'}, [
+        h('div', option.name),
+        h('div', {class: 'text-xs text-gray-500'}, option.folder)
+      ])
     },
 
     /*
@@ -539,21 +452,21 @@ export default {
       if (isEmptyObject(this.selectedTask)) return;
 
       clickupService
-        .deleteTimeTrackingEntry(this.selectedTask.entryId)
-        .then(() => {
-          const taskIndex = this.events.findIndex(
-            (event) => event.entryId === this.selectedTask.entryId
-          );
+          .deleteTimeTrackingEntry(this.selectedTask.entryId)
+          .then(() => {
+            const taskIndex = this.events.findIndex(
+                (event) => event.entryId === this.selectedTask.entryId
+            );
 
-          this.events.splice(taskIndex, 1);
-          this.showTaskDetailsModal = false;
-          this.selectedTask = {};
-        })
-        .catch(error => this.error({
+            this.events.splice(taskIndex, 1);
+            this.showTaskDetailsModal = false;
+            this.selectedTask = {};
+          })
+          .catch(error => this.error({
             error,
             title: "Delete failed",
             content: "There was a problem while calling Clickup. Check your console & internet connection and try again",
-        }));
+          }));
     },
 
     /*
@@ -562,16 +475,14 @@ export default {
     |--------------------------------------------------------------------------
     */
 
-    onTaskSingleClick(event, e) {
+    onTaskSingleClick(event) {
       this.selectedTask = event;
-      e.stopPropagation();
     },
 
-    onTaskDoubleClick(event, e) {
+    onTaskDoubleClick(event) {
       this.selectedTask = event;
 
       this.showTaskDetailsModal = true;
-      e.stopPropagation();
     },
 
     closeDetailModal() {
@@ -584,46 +495,39 @@ export default {
     |--------------------------------------------------------------------------
     */
 
-    updateTimeTrackingEntry({ event, originalEvent }) {
+    updateTimeTrackingEntry({event, originalEvent}) {
       clickupService.updateTimeTrackingEntry(
           event.entryId,
           event.description,
           event.start,
           event.end
-        )
-        .then((entry) => {
-          // Update the modeled event so copy/paste/duplicate works properly
-          const eventIndex = this.events.findIndex(
-            (e) => e.entryId === event.entryId
-          );
+      )
+          .then((entry) => {
+            // Update the modeled event so copy/paste/duplicate works properly
+            const eventIndex = this.events.findIndex(
+                (e) => e.entryId === event.entryId
+            );
 
-          if (eventIndex === -1) return;
+            if (eventIndex === -1) return;
 
+            this.events[eventIndex] = eventFactory.updateFromRemote(
+                this.events[eventIndex],
+                entry
+            );
 
-          console.dir({
-            before: this.events[eventIndex],
-            after: entry,
-            index: eventIndex
+            this.closeDetailModal()
+
+            console.dir(`Updated time tracking entry for: ${entry.task.name}`);
           })
-
-          this.events[eventIndex] = eventFactory.updateFromRemote(
-              this.events[eventIndex],
-              entry
-          );
-
-          this.closeDetailModal()
-
-          console.dir(`Updated time tracking entry for: ${entry.task.name}`);
-        })
-        .catch(error => {
-          this.error({
-            error,
-            duration: 5000,
-            title: "Update failed",
-            content: "There was a problem while pushing to Clickup. Check your console & internet connection and refresh the app",
+          .catch(error => {
+            this.error({
+              error,
+              duration: 5000,
+              title: "Update failed",
+              content: "There was a problem while pushing to Clickup. Check your console & internet connection and refresh the app",
+            });
+            // TODO: Reset event to what it was before failed update
           });
-          // TODO: Reset event to what it was before failed update
-        });
 
       originalEvent; /*  */
     },
@@ -634,54 +538,54 @@ export default {
     |--------------------------------------------------------------------------
     */
     totalHoursOnDate(date, events) {
-        let totalMinutes = events
-            .filter(event => event.start.getDate() == date.getDate())
-            .reduce((carry, event) => carry + (event.endTimeMinutes - event.startTimeMinutes), 0)
+      let totalMinutes = events
+          .filter(event => event.start.getDate() == date.getDate())
+          .reduce((carry, event) => carry + (event.endTimeMinutes - event.startTimeMinutes), 0)
 
-        let hours = Math.floor(totalMinutes / 60)
-        let minutes = totalMinutes % 60
+      let hours = Math.floor(totalMinutes / 60)
+      let minutes = totalMinutes % 60
 
-        if (totalMinutes === 0) {
-            return
-        }
+      if (totalMinutes === 0) {
+        return
+      }
 
-        return hours + ':' + String(minutes).padStart(2, '0')
+      return hours + ':' + String(minutes).padStart(2, '0')
     },
 
     hasTimeTrackedOn(date, events) {
-        return Boolean(
-            events.find(event => event.start.getDate() == date.getDate())
-        )
+      return Boolean(
+          events.find(event => event.start.getDate() == date.getDate())
+      )
     },
 
     fetchMentionableUsers() {
-        clickupService.getCachedUsers().then(users => {
-            this.mentionable = users.map(user => ({
-                label: user.username.toLowerCase(),
-                value: user.username.toLowerCase(),
-                avatar: user.profilePicture,
-                initials: user.initials
-            }))
-        })
+      clickupService.getCachedUsers().then(users => {
+        this.mentionable = users.map(user => ({
+          label: user.username.toLowerCase(),
+          value: user.username.toLowerCase(),
+          avatar: user.profilePicture,
+          initials: user.initials
+        }))
+      })
     },
 
     renderMentionLabel(option) {
-        return h('div', { style: 'display: flex; align-items: center;' }, [
-          h(NAvatar, {
-            style: 'margin-right: 8px;',
-            size: 24,
-            round: true,
-            src: option.avatar
-          }, option.avatar ? '' : option.initials,),
-          option.value
-        ])
+      return h('div', {style: 'display: flex; align-items: center;'}, [
+        h(NAvatar, {
+          style: 'margin-right: 8px;',
+          size: 24,
+          round: true,
+          src: option.avatar
+        }, option.avatar ? '' : option.initials,),
+        option.value
+      ])
     },
 
-    refreshBackgroundImage: function() {
+    refreshBackgroundImage: function () {
 
       const bg = document.getElementsByClassName('vuecal')[0];
       const url = store.get("settings.background_image_url")
-      if(!url) return
+      if (!url) return
 
       bg.style.backgroundImage = `url('${url}?${Math.random()}')`;
       bg.style.backgroundRepeat = "no-repeat";


### PR DESCRIPTION
**Depends on [PR #49](https://github.com/gwleuverink/clickup-time-tracker/pull/49)** 

Added a splash of color to the icons in the tree select implement in #49. Now the icons are colored based on the color supplied by the ClickUp API.

![Screenshot_20231124_100443](https://github.com/gwleuverink/clickup-time-tracker/assets/33897625/96e08c99-6b5b-4bd2-ae5e-f6a964372725)

I split this branch from another one where I am working on coloring the tracking entries, on this branch I added a setting to set a custom color. This feature is already capable a handling changing the icons to a set color when that setting becomes available. 

I also added a ClickUp items factory in the click up model file. This should make further definition changes to the click up model easier. By supplying the complete response from the API, and only defining the type, the definition of the model can be updated without changing all the places where the items are created. 

I saw that for the events there is a separate factory file. I don't know if something similar is preferred here, but it seems right to group all the click up items code into a single file. Please let me know what you think.